### PR TITLE
Rename sources to components. Adding ESB

### DIFF
--- a/source/components/.repos
+++ b/source/components/.repos
@@ -1,0 +1,6 @@
+# A list of urls to clone in (git source / doc path) tuples. ~ means Resources/doc.
+https://github.com/ongr-io/ConnectionsBundle ~
+https://github.com/ongr-io/ongr-sandbox src/ONGR/DemoBundle/Resources/doc
+https://github.com/ongr-io/MagentoConnectorBundle ~
+https://github.com/ongr-io/CookiesBundle ~
+https://github.com/ongr-io/ElasticsearchBundle ~

--- a/source/conf-travis.py
+++ b/source/conf-travis.py
@@ -67,7 +67,12 @@ copyright = u'2015, ONGR Team'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['*.php', '**/vendor', 'handbook/snippets'] # 'API/*', '**/Tests'
+exclude_patterns = [
+    '*.php',
+    '**/vendor',
+    'handbook/snippets',
+    'components/ConnectionsBundle/Resources/doc/index.rst',
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/source/conf.py
+++ b/source/conf.py
@@ -2,5 +2,5 @@
 
 execfile("conf-travis.py")
 
-# Pulling all repositry sources
+# Pulling all repository components
 execfile("pull.py")

--- a/source/conf.py
+++ b/source/conf.py
@@ -2,5 +2,5 @@
 
 execfile("conf-travis.py")
 
-# Pulling all repository components
+# Pulling all repository components.
 execfile("pull.py")

--- a/source/connectors.rst
+++ b/source/connectors.rst
@@ -5,4 +5,4 @@ Connectors
     :maxdepth: 1
     :titlesonly:
 
-    Magento <sources/MagentoConnectorBundle.git/Resources/doc/index>
+    Magento <components/MagentoConnectorBundle/Resources/doc/index>

--- a/source/customizations.rst
+++ b/source/customizations.rst
@@ -5,6 +5,6 @@ Customizations
     :maxdepth: 2
     :titlesonly:
 
-    Importing <sources/ConnectionsBundle.git/Resources/doc/import>
+    Importing <components/ConnectionsBundle/Resources/doc/import>
     syncing
-    sources/ConnectionsBundle.git/Resources/doc/url_invalidator
+    components/ConnectionsBundle/Resources/doc/url_invalidator

--- a/source/handbook/contributing/documentation.rst
+++ b/source/handbook/contributing/documentation.rst
@@ -5,7 +5,7 @@ Why?
 ----
 
 Readthedocs compiles documentation from one repository only. We have many.
-So this repository clones other repositories defined in sources/.repos and lets you have documentation from a number of (public) repositories.
+So this repository clones other repositories defined in components/.repos and lets you have documentation from a number of (public) repositories.
 
 How to: Test whether your documentation builds locally
 ------------------------------------------------------
@@ -126,7 +126,7 @@ As the following method makes sphinx sad, while using `:doc:` directive makes Gi
 Usage
 -----
 
-Add git repositories to sources/.repos file.
+Add git repositories to components/.repos file.
 Publish it on github, add as a project to readthedocs.
 Build and enjoy.
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -11,12 +11,13 @@ Contents
 .. toctree::
     :titlesonly:
 
-    sources/ongr-sandbox.git/src/ONGR/DemoBundle/Resources/doc/index
+    components/ongr-sandbox/src/ONGR/DemoBundle/Resources/doc/index
     handbook/requirements
     connectors
     customizations
     handbook/contributing/index
-    sources/CookiesBundle.git/Resources/doc/index
+    components/CookiesBundle/Resources/doc/index
+    components/ElasticsearchBundle/Resources/doc/index
 
 Community
 ---------

--- a/source/pull.py
+++ b/source/pull.py
@@ -2,7 +2,7 @@
 
 import string
 
-lines = [line.strip() for line in open('%s/sources/.repos' % (os.path.dirname(os.path.realpath(__file__))))]
+lines = [line.strip() for line in open('%s/components/.repos' % (os.path.dirname(os.path.realpath(__file__))))]
 
 for line in lines:
     if ( line[0]!="#" ) :
@@ -10,7 +10,7 @@ for line in lines:
         if doc_directory == '~':
             doc_directory = 'Resources/doc'
 
-        os.system("cd sources; mkdir %s; cd %s; git init; git remote add -f origin %s; git config core.sparsecheckout true; echo '%s' > .git/info/sparse-checkout; echo 'Resources/API' >> .git/info/sparse-checkout; git pull origin master;" % (repository_url.split("/")[-1], repository_url.split("/")[-1], repository_url, doc_directory))
+        os.system("cd components; mkdir %s; cd %s; git init; git remote add -f origin %s; git config core.sparsecheckout true; echo '%s' > .git/info/sparse-checkout; echo 'Resources/API' >> .git/info/sparse-checkout; git pull origin master;" % (repository_url.split("/")[-1], repository_url.split("/")[-1], repository_url, doc_directory))
 
 # fix links to githubs' .rst files.
-os.system("grep -rl '.rst' sources/ | grep -v '/.git/' | xargs perl -pe 's/\`(.*)<(.*)\.rst>\`_/$1:doc:`$2`/g' -i")
+os.system("grep -rl '.rst' components/ | grep -v '/.git/' | xargs perl -pe 's/\`(.*)<(.*)\.rst>\`_/$1:doc:`$2`/g' -i")

--- a/source/sources/.repos
+++ b/source/sources/.repos
@@ -1,5 +1,0 @@
-# a list of urls to clone
-https://github.com/ongr-io/ConnectionsBundle.git ~
-https://github.com/ongr-io/ongr-sandbox.git src/ONGR/DemoBundle/Resources/doc
-https://github.com/ongr-io/MagentoConnectorBundle.git ~
-https://github.com/ongr-io/CookiesBundle.git ~

--- a/source/syncing.rst
+++ b/source/syncing.rst
@@ -5,10 +5,10 @@ Syncing Data
     :maxdepth: 1
     :titlesonly:
 
-    sources/ConnectionsBundle.git/Resources/doc/sync
-    sources/ConnectionsBundle.git/Resources/doc/diff_provider
-    sources/ConnectionsBundle.git/Resources/doc/binlog
-    sources/ConnectionsBundle.git/Resources/doc/sync_storage
-    sources/ConnectionsBundle.git/Resources/doc/extractor
-    sources/ConnectionsBundle.git/Resources/doc/continuous_sync
-    sources/ConnectionsBundle.git/Resources/doc/diff_import
+    components/ConnectionsBundle/Resources/doc/sync
+    components/ConnectionsBundle/Resources/doc/diff_provider
+    components/ConnectionsBundle/Resources/doc/binlog
+    components/ConnectionsBundle/Resources/doc/sync_storage
+    components/ConnectionsBundle/Resources/doc/extractor
+    components/ConnectionsBundle/Resources/doc/continuous_sync
+    components/ConnectionsBundle/Resources/doc/diff_import


### PR DESCRIPTION
`sources/` directory is not being created so it's OK. Nothing references it anymore. All links are ok, no warnings.