### PR TITLE
Added .. GITHUB_HIDEME magic comment support

### DIFF
--- a/source/pull.py
+++ b/source/pull.py
@@ -13,5 +13,8 @@ for line in lines:
         repository_name = repository_url.split("/")[-1]
         os.system("mkdir _components; cd _components; mkdir %s; cd %s; git init; git remote add -f origin %s; git config core.sparsecheckout true; echo '%s' > .git/info/sparse-checkout; echo 'Resources/API' >> .git/info/sparse-checkout; git reset --hard; git pull origin master; cd ../../components; rm -rf %s; ln -s ../_components/%s/%s %s; cd .." % (repository_name, repository_name, repository_url, doc_directory, repository_name, repository_name, doc_directory, repository_name))
 
-# fix links to githubs' .rst files.
+# Fix links to githubs' .rst files.
 os.system("grep -rl '.rst' components/ | grep -v '/.git/' | xargs perl -pe 's/\`(.*?)<(.*?)\.rst>\`_/:doc:`$1<$2>`/g' -i")
+
+# Unhide things we have deemed unshowable in github
+os.system("grep -rl '.rst' components/ | grep -v '/.git/' | xargs perl -pe 's/\\.\. GITHUB_HIDEME//g' -i")


### PR DESCRIPTION
magic comment ```.. GITHUB_HIDEME (stuff)``` should not be visible in Github, but `(stuff)` should be visible in readthedocs docs.